### PR TITLE
ST-2224: Setting master branch to use 5.4.0-SNAPSHOT

### DIFF
--- a/control-center/pom.xml
+++ b/control-center/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent.control-center-images</groupId>
         <artifactId>control-center-images-parent</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>5.3.1-SNAPSHOT</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
     <name>Control Center Docker Images</name>
     <description>Build files for Confluent's control center Docker images</description>
-    <version>5.3.1-SNAPSHOT</version>
+    <version>5.4.0-SNAPSHOT</version>
 
     <modules>
         <module>control-center</module>


### PR DESCRIPTION
The master branch should be using 5.4.0. At the time of the original commit I was testing against 5.3.1 because that was more stable.