### PR TITLE
Add C3 'cprest.url' config for 5.4.x

### DIFF
--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -26,6 +26,7 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
     'CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS': 'confluent.metadata.bootstrap.server.urls',
     'CONFLUENT_METADATA_BASIC_AUTH_USER_INFO':'confluent.metadata.basic.auth.user.info',
     'PUBLIC_KEY_PATH': 'public.key.path',
+    'CONTROL_CENTER_CPREST_URL': 'cprest.url',
 } -%}
 
 {% set excludes = [] -%}


### PR DESCRIPTION
PR from yesterday should be merged into 5.4.x
https://github.com/confluentinc/control-center-images/pull/20