### PR TITLE
ST-2560: Adding labels required by RedHat container registry

### DIFF
--- a/control-center/Dockerfile.deb8
+++ b/control-center/Dockerfile.deb8
@@ -15,17 +15,16 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=latest
- 
+
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
-MAINTAINER partner-support@confluent.io
+
+LABEL maintainer="partner-support@confluent.io"
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+ARG GIT_COMMIT
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
 

--- a/control-center/Dockerfile.rhel8
+++ b/control-center/Dockerfile.rhel8
@@ -15,19 +15,24 @@
 
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG=rhel8-latest
- 
+
 FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
 
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
- 
-# Make sure you use an appropriate contact address.
-LABEL maintianer="partner-support@confluent.io"
+ARG GIT_COMMIT
+
+LABEL maintainer="partner-support@confluent.io"
+LABEL vendor="Confluent"
+LABEL version=$GIT_COMMIT
+LABEL release=$PROJECT_VERSION
+LABEL name=$ARTIFACT_ID
+LABEL summary="Confluent Control Center is a web-based graphical user interface that helps you operate and build event streaming applications with Apache Kafka."
 LABEL io.confluent.docker=true
-ARG COMMIT_ID=unknown
-LABEL io.confluent.docker.git.id=$COMMIT_ID
+LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1
 LABEL io.confluent.docker.build.number=$BUILD_NUMBER
+LABEL io.confluent.docker.git.repo="confluentinc/control-center-images"
 
 ENV COMPONENT=control-center 
 ENV CONTROL_CENTER_DATA_DIR=/var/lib/confluent-${COMPONENT}


### PR DESCRIPTION
These labels are required to pass the RedHat certification process for uploading images to the container registry.