### PR TITLE
ST-3599: Remove show_env function because it exposes secrets

### DIFF
--- a/control-center/include/etc/confluent/docker/run
+++ b/control-center/include/etc/confluent/docker/run
@@ -22,9 +22,6 @@
 #Ignoring Mesos override errors
 . /etc/confluent/docker/apply-mesos-overrides || true
 
-echo "===> ENV Variables ..."
-show_env
-
 echo "===> User"
 id
 


### PR DESCRIPTION
We don't want to print the environment variables in the logs during startup because they contain sensitive data.