### PR TITLE
update properties template to included addition monitoring properties

### DIFF
--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -15,6 +15,8 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC': 'confluent.monitoring.interceptor.topic',
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS': 'confluent.monitoring.interceptor.topic.partitions',
     'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_RETENTION_MS': 'confluent.monitoring.interceptor.topic.retention.ms',
+    'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION': 'confluent.monitoring.interceptor.topic.replication',
+    'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_SKIP_BACKLOG_MINUTES': 'confluent.monitoring.interceptor.topic.skip.backlog.minutes'
     'CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS': 'confluent.controlcenter.internal.topics.partitions',
     'CONTROL_CENTER_INTERNAL_TOPICS_RETENTION_MS': 'confluent.controlcenter.internal.topics.retention.ms',
     'CONTROL_CENTER_INTERNAL_TOPICS_CHANGELOG_SEGEMENT_BYTES': 'confluent.controlcenter.internal.topics.changelog.segment.bytes',


### PR DESCRIPTION
Currently there are properties that don't map correctly in docker template by default based on available parameters per the docs:
https://docs.confluent.io/current/control-center/installation/configuration.html#monitoring-settings

Specifically missing: 
confluent.monitoring.interceptor.topic.replication
confluent.monitoring.interceptor.topic.skip.backlog.minutes

Testing: (manual validation pending - will edit to use this custom template and use cp-demo for verification)