### PR TITLE
ST-4240: remove yum update in non base Docker images

### DIFF
--- a/control-center/Dockerfile.ubi8
+++ b/control-center/Dockerfile.ubi8
@@ -48,7 +48,6 @@ ARG CONFLUENT_PLATFORM_LABEL
 USER root
 
 RUN echo "===> Installing ${COMPONENT}..." \
-    && yum -q -y update \
     && rpm --import ${CONFLUENT_PACKAGES_REPO}/archive.key \
     && printf "[Confluent.dist] \n\
 name=Confluent repository (dist) \n\


### PR DESCRIPTION
non base docker scripts that run yum update will cause issues because we rely on the base image's package versions, not the packages yup update fetches