### PR TITLE
[MMA-9263]: Allow "config.providers" properties to be specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# intellij
+.idea
+*.iml

--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -27,6 +27,8 @@ confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPL
     'CONFLUENT_METADATA_BASIC_AUTH_USER_INFO':'confluent.metadata.basic.auth.user.info',
     'PUBLIC_KEY_PATH': 'public.key.path',
     'CONTROL_CENTER_CPREST_URL': 'cprest.url',
+    'CONFIG_PROVIDERS': 'config.providers',
+    'CONFIG_PROVIDERS_SECUREPASS_CLASS': 'config.providers.securepass.class',
 } -%}
 
 {% set excludes = [] -%}


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/MMA-9263

What
Allow users to pass `config.providers*`properties required to encrypt password/secrets