### PR TITLE
Add description label to Dockerfile

### DIFF
--- a/control-center/Dockerfile.ubi8
+++ b/control-center/Dockerfile.ubi8
@@ -28,6 +28,7 @@ LABEL version=$GIT_COMMIT
 LABEL release=$PROJECT_VERSION
 LABEL name=$ARTIFACT_ID
 LABEL summary="Confluent Control Center is a web-based graphical user interface that helps you operate and build event streaming applications with Apache Kafka."
+LABEL description="Confluent Control Center is a web-based graphical user interface that helps you operate and build event streaming applications with Apache Kafka."
 LABEL io.confluent.docker=true
 LABEL io.confluent.docker.git.id=$GIT_COMMIT
 ARG BUILD_NUMBER=-1


### PR DESCRIPTION
Some image scanning tools that check for vulnerabilities and OCI image best
practices expect to find a `description` label on images that is _not_ inherited
from base images. The proposed change addresses this requirement.