### PR TITLE
build: Remove confluent yum/apt repo after installation

### DIFF
--- a/control-center/Dockerfile.deb8
+++ b/control-center/Dockerfile.deb8
@@ -44,14 +44,14 @@ ARG ALLOW_UNSIGNED
 
 RUN echo "===> Installing ${COMPONENT}..." \
     && apt-get update \
+    && apt-get install -y apt-transport-https software-properties-common \
     && echo "===> Adding confluent repository...${CONFLUENT_PACKAGES_REPO}" \
-    && if [ "x$ALLOW_UNSIGNED" = "xtrue" ]; then echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/allow_unauthenticated; else curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key -o /tmp/archive.key && apt-key add /tmp/archive.key; fi \
-    && echo "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" >> /etc/apt/sources.list \
-    && cat /etc/apt/sources.list \
-    && apt-get install -y apt-transport-https \
+    && curl -s -L ${CONFLUENT_PACKAGES_REPO}/archive.key | apt-key add - \
+    && apt-add-repository "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get update \
     && apt-get install -y confluent-${COMPONENT}=${CONFLUENT_VERSION}${CONFLUENT_PLATFORM_LABEL}-${CONFLUENT_DEB_VERSION} \
     && echo "===> Cleaning up ..." \
+    && apt-add-repository --remove "deb [arch=amd64] ${CONFLUENT_PACKAGES_REPO} stable main" \
     && apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \

--- a/control-center/Dockerfile.ubi8
+++ b/control-center/Dockerfile.ubi8
@@ -65,7 +65,7 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && yum install -y confluent-${COMPONENT}-${CONFLUENT_VERSION} \
     && echo "===> Cleaning up ..."  \
     && yum clean all \
-    && rm -rf /tmp/* \
+    && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
     && chown appuser:appuser -R "${CONTROL_CENTER_DATA_DIR}" \


### PR DESCRIPTION
Couple of changes:
* Remove confluent's repo config. Confluent's images don't need to be able to update to the next CP release (Customers should be consuming the next versioned docker release)
* Removed the `AllowUnauthenticated` piece: In practice, we always import the public key for GPG automation validation.