### PR TITLE
fix: Restore root group write access to directories

### DIFF
--- a/control-center/Dockerfile.ubi8
+++ b/control-center/Dockerfile.ubi8
@@ -68,9 +68,9 @@ enabled=1 " > /etc/yum.repos.d/confluent.repo \
     && rm -rf /tmp/* /etc/yum.repos.d/confluent.repo \
     && echo "===> Setting up ${COMPONENT} dirs" \
     && mkdir -p "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:appuser -R "${CONTROL_CENTER_DATA_DIR}" \
-    && chown appuser:appuser -R "${CONTROL_CENTER_CONFIG_DIR}" \
-    && chmod -R g+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
+    && chown appuser:root -R "${CONTROL_CENTER_DATA_DIR}" \
+    && chown appuser:root -R "${CONTROL_CENTER_CONFIG_DIR}" \
+    && chmod -R ug+w "${CONTROL_CENTER_CONFIG_DIR}" "${CONTROL_CENTER_DATA_DIR}"
 
 COPY --chown=appuser:appuser include/etc/confluent/docker /etc/confluent/docker
 


### PR DESCRIPTION
This restores the root groups write access to confluent service directories.

Internally (@rohit2b) and externally (@erikgb) this change works in an OpenShift context.