### PR TITLE
MMA-11806: Stop hardhoding confluent.metrics.* and confluent.monitoring.interceptor.* properties

### DIFF
--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -1,3 +1,7 @@
+{# ********************************************************************************************** #}
+{# IMPORTANT TO NOTE: These properties are required properties, and they not only have special #}
+{# translations but also have a list of valid translations. #}
+{# ********************************************************************************************** #}
 {% set required_props = {
   'bootstrap.servers': ['CONTROL_CENTER_BOOTSTRAP_SERVERS'],
   'zookeeper.connect': ['CONTROL_CENTER_ZOOKEEPER_CONNECT'],
@@ -8,28 +12,25 @@
   'confluent.metrics.topic.replication': ['CONTROL_CENTER_METRICS_TOPIC_REPLICATION', 'CONFLUENT_METRICS_TOPIC_REPLICATION', 'CONTROL_CENTER_REPLICATION_FACTOR']
 } -%}
 
-{% set metrics_props = {
-    'confluent.metrics.topic': ['CONTROL_CENTER_METRICS_TOPIC', 'CONFLUENT_METRICS_TOPIC'],
-    'confluent.metrics.topic.retention.ms': ['CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS', 'CONFLUENT_METRICS_TOPIC_RETENTION_MS'],
-    'confluent.metrics.topic.partitions': ['CONTROL_CENTER_METRICS_TOPIC_PARTITIONS', 'CONFLUENT_METRICS_TOPIC_PARTITIONS'],
-    'confluent.metrics.topic.skip.backlog.minutes': ['CONTROL_CENTER_METRICS_TOPIC_SKIP_BACKLOG_MINUTES', 'CONFLUENT_METRICS_TOPIC_SKIP_BACKLOG_MINUTES']
-} -%}
-
-{% set monitoring_props = {
-    'confluent.monitoring.interceptor.topic': ['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC'],
-    'confluent.monitoring.interceptor.topic.partitions': ['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS'],
-    'confluent.monitoring.interceptor.topic.retention.ms': ['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_RETENTION_MS'],
-    'confluent.monitoring.interceptor.topic.skip.backlog.minutes': ['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_SKIP_BACKLOG_MINUTES']
-} -%}
-
+{# ********************************************************************************************** #}
 {# IMPORTANT TO NOTE: These properties have uncommon prefixes. Though ideally C3 properties should #}
 {# have the common prefix `confluent.controlcenter.`, which translates to `CONTROL_CENTER_`. #}
-{% set other_props = {
+{# ********************************************************************************************** #}
+{% set special_props = {
     'confluent.license': ['CONTROL_CENTER_LICENSE', 'CONTROL_CENTER_CONFLUENT_LICENSE'],
     'public.key.path': ['PUBLIC_KEY_PATH']
 } -%}
 
-{% macro SET_PROPERTIES(properties, required, excludes) -%}
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES should be used for properties that have special translation, and have a list of #}
+{# valid translations that could be used. For example, confluent.metrics.topic has two valid #}
+{# possible translations: [CONTROL_CENTER_METRICS_TOPIC, CONFLUENT_METRICS_TOPIC]. SET_PROPERTIES #}
+{# will try all the possible translations. If a property is required and none of the possible #}
+{# translation was configured in the env variables, then the property is set to an empty string. #}
+{# If a property is not required and none of the possible translation was configured in the env #}
+{# variables, nothing will be set. Each translated property is appended to excludes as well. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES(properties, required, excludes=[]) -%}
 {% for property, ks in properties.items() -%}
 {# ENCAPSULATE THE VALUE AS RESULT #}
 {% set ns = namespace(result=None) -%}
@@ -52,18 +53,53 @@
 {% endfor -%}
 {% endmacro -%}
 
-{% macro SET_PROPERTIES_WITH_ENV_TO_PROPS(env_prefix, prop_prefix, exclude=[]) -%}
-{% set props = env_to_props(env_prefix, prop_prefix, exclude=exclude) -%}
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_ENV_TO_PROPS should be used for properties that have a fixed translation #}
+{# to the env variable. For example, everything starts with CONTROL_METADATA_ deterministically #}
+{# always translates to confluent.metadata. Each translated property is NOT appended to excludes
+{# (because of the way env_to_props was implemented). #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_ENV_TO_PROPS(env_prefix, prop_prefix, excludes=[]) -%}
+{% set props = env_to_props(env_prefix, prop_prefix, exclude=excludes) -%}
 {% for name, value in props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
 {% endmacro -%}
 
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_SKIP_PROP_CHECK should be used for properties that in general have a fixed #}
+{# translation, but have a few props prefixes that should be skipped. For example, properties #}
+{# that start with CONTROL_CENTER_ in general translates to confluent.controlcenter. However, #}
+{# CONTROL_CENTER_METRICS_* and CONTROL_CENTER_MONITORING_INTERCEPTOR_* also start with #}
+{# CONTROL_CENTER_ but they are special and should be skipped. Each translated property is NOT
+{# appended to excludes. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_SKIP_PROP_CHECK(env_prefix, prop_prefix, excludes=[], skip_prop_prefix=[], skip_props=[]) -%}
+{% set props = env_to_props(env_prefix, prop_prefix, exclude=excludes) -%}
+{# CHECK IF NAME STARTS WITH A PROPERTY PREFIX THAT SHOULD BE SKIPPED #}
+{% for name, value in props.items() -%}
+{% for w in skip_prop_prefix -%}
+{% if w in name %}
+{% set _ = skip_props.append(name) -%}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{# SET IN TEMPLATE FILE ONLY IF NAME SHOULDN'T BE SKIPPED #}
+{% for name, value in props.items() -%}
+{% if not name in skip_props -%}
+{{name}}={{value}}
+{% endif -%}
+{% endfor -%}
+{% endmacro -%}
+
 {% set excludes = [] -%}
 {{ SET_PROPERTIES(required_props, true, excludes) }}
-{{ SET_PROPERTIES(metrics_props, false, excludes) }}
-{{ SET_PROPERTIES(monitoring_props, false, excludes) }}
-{{ SET_PROPERTIES(other_props, false, excludes) }}
-{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_', 'confluent.controlcenter.', excludes) }}
+{{ SET_PROPERTIES(special_props, false, excludes) }}
+
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_METRICS_', 'confluent.metrics.', excludes) }}
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_METRICS_', 'confluent.metrics.', excludes) }}
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_MONITORING_INTERCEPTOR_', 'confluent.monitoring.interceptor.', excludes) }}
 {{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_METADATA_', 'confluent.metadata.', excludes) }}
 {{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_SUPPORT_', 'confluent.support.', excludes) }}
+
+{{ SET_PROPERTIES_WITH_SKIP_PROP_CHECK('CONTROL_CENTER_', 'confluent.controlcenter.', excludes, ['confluent.controlcenter.metrics.', 'confluent.controlcenter.monitoring.interceptor.']) }}

--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -24,8 +24,8 @@
 {# ********************************************************************************************** #}
 {# SET_PROPERTIES should be used for properties that have special translation, and have a list of #}
 {# valid translations that could be used. For example, confluent.metrics.topic has two valid #}
-{# possible translations: [CONTROL_CENTER_METRICS_TOPIC, CONFLUENT_METRICS_TOPIC]. SET_PROPERTIES #}
-{# will try all the possible translations. If a property is required and none of the possible #}
+{# possible translations: [CONTROL_CENTER_METRICS_TOPIC_REPLICATION, CONFLUENT_METRICS_TOPIC_REPLICATION]. #}
+{# SET_PROPERTIES will try all the possible translations. If a property is required and none of the possible #}
 {# translation was configured in the env variables, then the property is set to an empty string. #}
 {# If a property is not required and none of the possible translation was configured in the env #}
 {# variables, nothing will be set. Each translated property is appended to excludes as well. #}
@@ -67,12 +67,39 @@
 {% endmacro -%}
 
 {# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES should be used for properties that have two #}
+{# fixed translations to the env variables. For example, for metrics properties, both #}
+{# CONTROL_CENTER_METRICS_ and CONFLUENT_METRICS_ deterministically always translate to #}
+{# confluent.metrics. However, the first env prefix takes precedence. Therefore, this function #}
+{# only sets a property that starts with the secondary env prefix if the property hasn't been set #}
+{# with the primary env prefix. We shouldn't find two copies of the same property being translated #}
+{# by both the primary and the secondary env prefix. Each translated property is NOT appended to #}
+{# excludes. #}
+{# Note this func could be deleted if env_to_props appends each translated property to excludes. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES(primary_env_prefix, secondary_env_prefix, prop_prefix, excludes=[]) -%}
+{% set primary_props = env_to_props(primary_env_prefix, prop_prefix, exclude=excludes) -%}
+{% set secondary_props = env_to_props(secondary_env_prefix, prop_prefix, exclude=excludes) -%}
+{# SET PROPERTIES PREFIXED WITH primary_env_prefix BECAUSE THEY ALWAYS TAKE PRECEDENCE #}
+{% for name, value in primary_props.items() -%}
+{{name}}={{value}}
+{% endfor -%}
+{# SET PROPERTIES PREFIXED WITH secondary_env_prefix ONLY IF THE PROP HASN'T BEEN SET YET #}
+{% for name, value in secondary_props.items() -%}
+{% if name not in primary_props.keys() -%}
+{{name}}={{value}}
+{% endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+{# ********************************************************************************************** #}
 {# SET_PROPERTIES_WITH_SKIP_PROP_CHECK should be used for properties that in general have a fixed #}
 {# translation, but have a few props prefixes that should be skipped. For example, properties #}
 {# that start with CONTROL_CENTER_ in general translates to confluent.controlcenter. However, #}
 {# CONTROL_CENTER_METRICS_* and CONTROL_CENTER_MONITORING_INTERCEPTOR_* also start with #}
 {# CONTROL_CENTER_ but they are special and should be skipped. Each translated property is NOT
 {# appended to excludes. #}
+{# Note this func could be deleted if env_to_props appends each translated property to excludes. #}
 {# ********************************************************************************************** #}
 {% macro SET_PROPERTIES_WITH_SKIP_PROP_CHECK(env_prefix, prop_prefix, excludes=[], skip_prop_prefix=[], skip_props=[]) -%}
 {% set props = env_to_props(env_prefix, prop_prefix, exclude=excludes) -%}
@@ -96,10 +123,10 @@
 {{ SET_PROPERTIES(required_props, true, excludes) }}
 {{ SET_PROPERTIES(special_props, false, excludes) }}
 
-{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_METRICS_', 'confluent.metrics.', excludes) }}
-{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_METRICS_', 'confluent.metrics.', excludes) }}
 {{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_MONITORING_INTERCEPTOR_', 'confluent.monitoring.interceptor.', excludes) }}
 {{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_METADATA_', 'confluent.metadata.', excludes) }}
 {{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_SUPPORT_', 'confluent.support.', excludes) }}
+
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES('CONTROL_CENTER_METRICS_', 'CONFLUENT_METRICS_', 'confluent.metrics.', excludes) }}
 
 {{ SET_PROPERTIES_WITH_SKIP_PROP_CHECK('CONTROL_CENTER_', 'confluent.controlcenter.', excludes, ['confluent.controlcenter.metrics.', 'confluent.controlcenter.monitoring.interceptor.']) }}

--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -106,7 +106,7 @@
 {# CHECK IF NAME STARTS WITH A PROPERTY PREFIX THAT SHOULD BE SKIPPED #}
 {% for name, value in props.items() -%}
 {% for w in skip_prop_prefix -%}
-{% if w in name %}
+{% if name.startswith(w) %}
 {% set _ = skip_props.append(name) -%}
 {% endif -%}
 {% endfor -%}

--- a/control-center/test/test_control_center_props_validation.py
+++ b/control-center/test/test_control_center_props_validation.py
@@ -23,29 +23,23 @@ rf_props = dict(
 # complete set
 required_props = {**basic_props, **rf_props}
 
-# complete set
+# incomplete set
 monitoring_props = dict(
     CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC="confluent.monitoring.interceptor.topic",
-    CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS="confluent.monitoring.interceptor.topic.partitions",
-    CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_RETENTION_MS="confluent.monitoring.interceptor.topic.retention.ms",
-    CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_SKIP_BACKLOG_MINUTES="confluent.monitoring.interceptor.topic.skip.backlog.minutes"
+    CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS="confluent.monitoring.interceptor.topic.partitions"
 )
 
-# complete set
-remaining_control_center_metrics_props = dict(
+# incomplete set
+control_center_metrics_props = dict(
     CONTROL_CENTER_METRICS_TOPIC="confluent.metrics.topic",
-    CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS="confluent.metrics.topic.retention.ms",
-    CONTROL_CENTER_METRICS_TOPIC_PARTITIONS="confluent.metrics.topic.partitions",
-    CONTROL_CENTER_METRICS_TOPIC_SKIP_BACKLOG_MINUTES="confluent.metrics.topic.skip.backlog.minutes"
+    CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS="confluent.metrics.topic.retention.ms"
 )
 
-# complete set
+# incomplete set
 confluent_metrics_props = dict(
     CONFLUENT_METRICS_TOPIC="confluent.metrics.topic",
     CONFLUENT_METRICS_TOPIC_REPLICATION="confluent.metrics.topic.replication",
     CONFLUENT_METRICS_TOPIC_RETENTION_MS="confluent.metrics.topic.retention.ms",
-    CONFLUENT_METRICS_TOPIC_PARTITIONS="confluent.metrics.topic.partitions",
-    CONFLUENT_METRICS_TOPIC_SKIP_BACKLOG_MINUTES="confluent.metrics.topic.skip.backlog.minutes"
 )
 
 # incomplete set
@@ -60,14 +54,14 @@ metadata_props = dict(
     CONFLUENT_METADATA_CLUSTER_REGISTRY_ENABLE="confluent.metadata.cluster.registry.enable",
 )
 
-# complete set
+# incomplete set
 support_props = dict(
     CONFLUENT_SUPPORT_METRICS_ENABLE="confluent.support.metrics.enable",
     CONFLUENT_SUPPORT_METRICS_SEGMENT_ID="confluent.support.metrics.segment.id"
 )
 
 # complete set
-other_props = dict(
+special_props = dict(
     CONTROL_CENTER_LICENSE="confluent.license",
     PUBLIC_KEY_PATH="public.key.path"
 )
@@ -76,9 +70,9 @@ other_props = dict(
 env_to_c3_prop_lookup = {
     **required_props,
     **monitoring_props,
-    **remaining_control_center_metrics_props,
+    **control_center_metrics_props,
     **confluent_metrics_props,
-    **other_props,
+    **special_props,
     **c3_optional_props,
     **metadata_props,
     **support_props
@@ -118,16 +112,20 @@ class PropsTranslationTest(unittest.TestCase):
         cls.filled_template = dict(line.split("=") for line in actual)
 
     @classmethod
-    def configure_partially(cls, props, sample_size=2):
+    def configure_partially(cls, props, sample_size=1):
         configured_props = random.sample(props.keys(), sample_size)
         not_configured_props = list(set(props.keys()) - set(configured_props))
         return configured_props, not_configured_props
 
     @classmethod
     def check_translations(cls, env_props):
+        # assume env_prop = 'CONTROL_CENTER_ID'
         for env_prop in env_props:
+            # c3_prop is the correct c3 prop translation, which is 'confluent.controlcenter.id'
             c3_prop = env_to_c3_prop_lookup[env_prop]
+            # assume expected_val = '9999'
             expected_val = cls.test_env[env_prop]
+            # check if in the template file, confluent.controlcenter.id = 9999 as well
             cls.check_single_translation(c3_prop, expected_val)
 
     @classmethod
@@ -148,7 +146,7 @@ class PropsTranslationTest(unittest.TestCase):
         assert expected_len == actual_len, \
             "filled template expected length %s, got %s" % (expected_len, actual_len)
 
-    def test_missing_required_props(self):
+    def test_missing_required_properties(self):
         """
         Testing SET_PROPERTIES's logic of required vs. not required.
 
@@ -163,13 +161,13 @@ class PropsTranslationTest(unittest.TestCase):
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
-            # only required properties show up
+            # all required props show up, regardless of if they are configured or not
             self.check_filled_template_length(expected_len=len(required_props))
 
-            # some are set with their values
+            # required props that are configured show up with actual values
             self.check_translations(env_props=configured_props)
 
-            # some are set with empty string
+            # required props that are not configured show up with empty string
             for not_configured_prop in not_configured_props:
                 c3_prop = env_to_c3_prop_lookup[not_configured_prop]
 
@@ -190,57 +188,80 @@ class PropsTranslationTest(unittest.TestCase):
         :return: pass if when no environment variable is set, optional properties are not set
         """
         configured_props, not_configured_props = self.configure_partially(monitoring_props)
-        self.set_up_test_env(test_env_props=list(required_props.keys()) + configured_props)
+        self.set_up_test_env(test_env_props=configured_props)
 
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
+            # required props show up regardless of if they are configured or not;
+            # however, optional props only show up if they are actually configured.
             self.check_filled_template_length(
                 expected_len=len(required_props) + len(configured_props))
 
-            self.check_translations(env_props=basic_props.keys())
-
+            # optional props that are configured show up with actual values
             self.check_translations(env_props=configured_props)
 
+            # optional props that are not configured shouldn't show up at all
             for not_configured_prop in not_configured_props:
                 c3_prop = env_to_c3_prop_lookup[not_configured_prop]
 
                 assert c3_prop not in self.filled_template, \
                     "optional property %s shouldn't be set" % c3_prop
 
-    def test_rf_properties_use_default(self):
+    def test_rf_properties_precedence(self):
         """
         Testing SET_PROPERTIES's logic of precedence.
 
-        Test that replication factor properties default to CONTROL_CENTER_REPLICATION_FACTOR
+        1. Test that replication factor properties default to CONTROL_CENTER_REPLICATION_FACTOR
 
-        :return: pass if confluent.controlcenter.internal.topics.replication
-                         confluent.controlcenter.command.topic.replication
-                         confluent.metrics.topic.replication
-                         confluent.monitoring.interceptor.topic.replication
-                      default to use CONTROL_CENTER_REPLICATION_FACTOR when they're not set.
+            pass if confluent.controlcenter.internal.topics.replication
+                    confluent.controlcenter.command.topic.replication
+                    confluent.metrics.topic.replication
+                    confluent.monitoring.interceptor.topic.replication
+            default to use CONTROL_CENTER_REPLICATION_FACTOR when they're not set.
+
+        2. Test that replication factor properties use their own value
+
+            pass if the four rf props use their own value when corresponding env variable is set,
+            even though CONTROL_CENTER_REPLICATION_FACTOR is present as well.
+
+        :return: pass if both tests pass
         """
-        self.set_up_test_env(
-            test_env_props=list(basic_props.keys()) + [
-                'CONTROL_CENTER_REPLICATION_FACTOR'
-            ]
-        )
+        # 1. Test that replication factor properties default to CONTROL_CENTER_REPLICATION_FACTOR
+        self.set_up_test_env(test_env_props=['CONTROL_CENTER_REPLICATION_FACTOR'])
 
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
+            # required props show up regardless of if they are configured or not;
+            # rf props are part of the required props.
             self.check_filled_template_length(expected_len=len(required_props))
 
-            self.check_translations(env_props=basic_props.keys())
-
-            for rf_prop in rf_props.values():
+            # check that all rf props default to the value of CONTROL_CENTER_REPLICATION_FACTOR
+            for rf_prop in rf_props.keys():
                 self.check_single_translation(
-                    c3_prop=rf_prop,
+                    c3_prop=rf_props[rf_prop],
                     expected_val=self.test_env['CONTROL_CENTER_REPLICATION_FACTOR'])
 
-    def test_metrics_rf_property_respects_precedence(self):
+        # 2. Test that replication factor properties use their own value
+        self.set_up_test_env(test_env_props=['CONTROL_CENTER_REPLICATION_FACTOR'] + list(rf_props.keys()))
+
+        with patch.dict('os.environ', self.test_env):
+            self.fill_template()
+
+            # required props show up regardless of if they are configured or not;
+            # rf props are part of the required props.
+            self.check_filled_template_length(expected_len=len(required_props))
+
+            # check that all rf props use their own value even though CONTROL_CENTER_REPLICATION_FACTOR is configured
+            for rf_prop in rf_props.keys():
+                self.check_single_translation(
+                    c3_prop=rf_props[rf_prop],
+                    expected_val=self.test_env[rf_prop])
+
+    def test_metrics_rf_properties_precedence(self):
         """
-        Testing SET_PROPERTIES's logic of precedence.
+        Testing SET_PROPERTIES's logic of precedence, specifically metrics rf props.
 
         Test that confluent.metrics.topic.replication respect the following precedence:
             CONTROL_CENTER_METRICS_TOPIC_REPLICATION >
@@ -249,9 +270,9 @@ class PropsTranslationTest(unittest.TestCase):
 
         :return: pass if confluent.metrics.topic.replication respects the precedence
         """
-        # CONTROL_CENTER_METRICS_TOPIC_REPLICATION should take precedence
+        # 1. Test CONTROL_CENTER_METRICS_TOPIC_REPLICATION should take precedence
         self.set_up_test_env(
-            test_env_props=list(basic_props.keys()) + [
+            test_env_props=[
                 'CONTROL_CENTER_METRICS_TOPIC_REPLICATION',
                 'CONFLUENT_METRICS_TOPIC_REPLICATION',
                 'CONTROL_CENTER_REPLICATION_FACTOR'
@@ -261,17 +282,17 @@ class PropsTranslationTest(unittest.TestCase):
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
+            # required props show up regardless of if they are configured or not;
+            # rf props are part of the required props.
             self.check_filled_template_length(expected_len=len(required_props))
-
-            self.check_translations(env_props=basic_props.keys())
 
             self.check_single_translation(
                 c3_prop='confluent.metrics.topic.replication',
                 expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC_REPLICATION'])
 
-        # CONFLUENT_METRICS_TOPIC_REPLICATION should take precedence
+        # 2. Test CONFLUENT_METRICS_TOPIC_REPLICATION should take precedence
         self.set_up_test_env(
-            test_env_props=list(basic_props.keys()) + [
+            test_env_props=[
                 'CONFLUENT_METRICS_TOPIC_REPLICATION',
                 'CONTROL_CENTER_REPLICATION_FACTOR'
             ]
@@ -280,66 +301,56 @@ class PropsTranslationTest(unittest.TestCase):
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
+            # required props show up regardless of if they are configured or not;
+            # rf props are part of the required props.
             self.check_filled_template_length(expected_len=len(required_props))
-
-            self.check_translations(env_props=basic_props.keys())
 
             self.check_single_translation(
                 c3_prop='confluent.metrics.topic.replication',
                 expected_val=self.test_env['CONFLUENT_METRICS_TOPIC_REPLICATION'])
 
-        # for when only CONTROL_CENTER_REPLICATION_FACTOR is set, see unit test
-        # test_rf_properties_use_default
-
-    def test_remaining_metrics_props_respect_precedence(self):
+    def test_temp(self):
         """
-        Testing SET_PROPERTIES's logic of precedence.
+        Testing SET_PROPERTIES_WITH_SKIP_PROP_CHECK's logic of checking bad prefix.
 
-        Test that the remaining metrics-related properties also respect the following precedence:
-        CONTROL_CENTER_METRICS_* > CONFLUENT_METRICS_*
+        Test that SET_PROPERTIES_WITH_SKIP_PROP_CHECK avoids adding properties that start with
+        CONTROL_CENTER_METRICS_ (aka. confluent.controlcenter.metrics.) and those that start with
+        CONTROL_CENTER_MONITORING_INTERCEPTOR_ (aka. confluent.controlcenter.monitoring.interceptor.)
+        because these properties are special cases and are falsely translated, even though they
+        have the regular prefix CONTROL_CENTER_.
 
-        :return: pass if remaining metrics-related properties also respect the precedence
+        :return: pass if SET_PROPERTIES_WITH_SKIP_PROP_CHECK avoids adding properties with bad prefix.
         """
         self.set_up_test_env(
-            test_env_props=list(required_props.keys()) + [
-                # confluent.metrics.topic uses CONTROL_CENTER_METRICS_* since it takes precedence
-                'CONTROL_CENTER_METRICS_TOPIC', 'CONFLUENT_METRICS_TOPIC',
-                # confluent.metrics.topic.retention.ms uses CONTROL_CENTER_METRICS_*
-                'CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS',
-                # confluent.metrics.topic.partitions uses CONFLUENT_METRICS_*
-                'CONFLUENT_METRICS_TOPIC_PARTITIONS',
-                # confluent.metrics.topic.skip.backlog.minutes not set at all
+            test_env_props=[
+                # translated because ok prefix (logic of SET_PROPERTIES_WITH_ENV_TO_PROPS)
+                'CONTROL_CENTER_METRICS_TOPIC',
+                # translated because ok prefix but overwritten by the prev prop (logic of SET_PROPERTIES_WITH_ENV_TO_PROPS)
+                'CONFLUENT_METRICS_TOPIC',
+                # falsely translated because it starts with CONTROL_CENTER_ but not CONTROL_CENTER_METRIC_ (logic of SET_PROPERTIES_WITH_SKIP_PROP_CHECK)
+                'CONTROL_CENTER_METRIC_TOPIC',
+                # won't get translated because bad prefix
+                'CONFLUENT_METRIC_TOPIC',
             ]
         )
 
         with patch.dict('os.environ', self.test_env):
             self.fill_template()
 
-            # 3 more extra properties: metrics.topic, metrics.topic.retention.ms, metrics.partitions
-            self.check_filled_template_length(expected_len=len(required_props) + 3)
-
-            self.check_translations(env_props=basic_props.keys())
+            self.check_filled_template_length(expected_len=len(required_props) + 2)
 
             self.check_single_translation(
                 c3_prop='confluent.metrics.topic',
-                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC']
-            )
+                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC'])
 
             self.check_single_translation(
-                c3_prop='confluent.metrics.topic.retention.ms',
-                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS']
-            )
-
-            self.check_single_translation(
-                c3_prop='confluent.metrics.topic.partitions',
-                expected_val=self.test_env['CONFLUENT_METRICS_TOPIC_PARTITIONS']
-            )
-
-            assert 'confluent.metrics.topic.skip.backlog.minutes' not in self.filled_template
+                c3_prop='confluent.controlcenter.metric.topic',
+                expected_val=self.test_env['CONTROL_CENTER_METRIC_TOPIC'])
 
     def test_comprehensive(self):
         """
-        Testing SET_PROPERTIES and SET_PROPERTIES_WITH_ENV_TO_PROPS's logic combined.
+        Testing SET_PROPERTIES, SET_PROPERTIES_WITH_ENV_TO_PROPS, and
+        SET_PROPERTIES_WITH_SKIP_PROP_CHECK 's logic combined.
 
         Test the properties translation comprehensively.
 
@@ -349,7 +360,7 @@ class PropsTranslationTest(unittest.TestCase):
         configured_rf_props = list(rf_props.keys()) + ["CONTROL_CENTER_REPLICATION_FACTOR"]
 
         # metrics props should ignore "CONFLUENT_METRICS_*" because of precedence
-        configured_metrics_props = list(remaining_control_center_metrics_props.keys()) + \
+        configured_metrics_props = list(control_center_metrics_props.keys()) + \
             list(confluent_metrics_props.keys())
 
         # monitoring props should be partially set because they're optional props
@@ -357,16 +368,16 @@ class PropsTranslationTest(unittest.TestCase):
 
         # other props should ignore "CONTROL_CENTER_CONFLUENT_LICENSE" because of precedence and
         # should be partially set because they're optional props
-        configured_other_props = list(other_props.keys()) + ["CONTROL_CENTER_CONFLUENT_LICENSE"]
+        configured_other_props = list(special_props.keys()) + ["CONTROL_CENTER_CONFLUENT_LICENSE"]
 
         # c3 optional props should be partially set because they're optional props
-        configured_c3_optional_props, _ = self.configure_partially(c3_optional_props, sample_size=1)
+        configured_c3_optional_props, _ = self.configure_partially(c3_optional_props)
 
         # metadata props should be partially set because they're optional props
-        configured_metadata_props, _ = self.configure_partially(metadata_props, sample_size=1)
+        configured_metadata_props, _ = self.configure_partially(metadata_props)
 
         # support props should be partially set because they're optional props
-        configured_support_props, _ = self.configure_partially(support_props, sample_size=1)
+        configured_support_props, _ = self.configure_partially(support_props)
 
         self.set_up_test_env(test_env_props=list(basic_props.keys()) +
                              configured_rf_props +
@@ -382,9 +393,9 @@ class PropsTranslationTest(unittest.TestCase):
 
             to_check = [basic_props.keys(),
                         rf_props.keys(),
-                        remaining_control_center_metrics_props.keys(),
+                        control_center_metrics_props.keys(),
                         configured_monitoring_props,
-                        other_props,
+                        special_props,
                         configured_c3_optional_props,
                         configured_metadata_props,
                         configured_support_props]
@@ -394,3 +405,131 @@ class PropsTranslationTest(unittest.TestCase):
             for li in to_check:
                 self.check_translations(env_props=li)
 
+    def test_comprehensive_concrete_example(self):
+        self.set_up_test_env(
+            test_env_props=[
+                # copied from cp-all-in-one
+                'CONTROL_CENTER_BOOTSTRAP_SERVERS',
+                'CONTROL_CENTER_KSQL_KSQLDB1_URL',
+                'CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL',
+                'CONTROL_CENTER_SCHEMA_REGISTRY_URL',
+                'CONTROL_CENTER_SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE',
+                'CONTROL_CENTER_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO',
+                'CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER',
+                'CONTROL_CENTER_STREAMS_SECURITY_PROTOCOL',
+                'CONTROL_CENTER_STREAMS_SASL_JAAS_CONFIG',
+                'CONTROL_CENTER_STREAMS_SASL_MECHANISM',
+                'CONTROL_CENTER_REPLICATION_FACTOR',
+                'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION',
+                'CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION',
+                'CONTROL_CENTER_COMMAND_TOPIC_REPLICATION',
+                'CONTROL_CENTER_METRICS_TOPIC_REPLICATION',
+                'CONFLUENT_METRICS_TOPIC_REPLICATION',
+                'CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS',
+                'CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS',
+                'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS',
+                'CONTROL_CENTER_METRICS_TOPIC_MAX_MESSAGE_BYTES',
+
+                # special props
+                'CONTROL_CENTER_LICENSE',
+                'CONTROL_CENTER_CONFLUENT_LICENSE',
+                'PUBLIC_KEY_PATH',
+
+                # props with bad prefix
+                'CONTROL_CENTER_METRIC_TOPIC',
+                'CONTROL_CENTER_MONITORING_TOPIC',
+
+                # metrics topic precedence
+                'CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS',
+                'CONFLUENT_METRICS_TOPIC_RETENTION_MS'
+            ]
+        )
+        with patch.dict('os.environ', self.test_env):
+            self.fill_template()
+
+            self.check_filled_template_length(expected_len=25)
+
+            # copied from cp-all-in-one
+            self.check_single_translation(
+                c3_prop='bootstrap.servers',
+                expected_val=self.test_env['CONTROL_CENTER_BOOTSTRAP_SERVERS'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.ksql.ksqldb1.url',
+                expected_val=self.test_env['CONTROL_CENTER_KSQL_KSQLDB1_URL'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.ksql.ksqldb1.advertised.url',
+                expected_val=self.test_env['CONTROL_CENTER_KSQL_KSQLDB1_ADVERTISED_URL'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.schema.registry.url',
+                expected_val=self.test_env['CONTROL_CENTER_SCHEMA_REGISTRY_URL'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.schema.registry.basic.auth.credentials.source',
+                expected_val=self.test_env['CONTROL_CENTER_SCHEMA_REGISTRY_BASIC_AUTH_CREDENTIALS_SOURCE'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.schema.registry.basic.auth.user.info',
+                expected_val=self.test_env['CONTROL_CENTER_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.connect.connect-default.cluster',
+                expected_val=self.test_env['CONTROL_CENTER_CONNECT_CONNECT-DEFAULT_CLUSTER'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.streams.security.protocol',
+                expected_val=self.test_env['CONTROL_CENTER_STREAMS_SECURITY_PROTOCOL'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.streams.sasl.jaas.config',
+                expected_val=self.test_env['CONTROL_CENTER_STREAMS_SASL_JAAS_CONFIG'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.streams.sasl.mechanism',
+                expected_val=self.test_env['CONTROL_CENTER_STREAMS_SASL_MECHANISM'])
+            self.check_single_translation(
+                c3_prop='confluent.monitoring.interceptor.topic.replication',
+                expected_val=self.test_env['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.internal.topics.replication',
+                expected_val=self.test_env['CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.command.topic.replication',
+                expected_val=self.test_env['CONTROL_CENTER_COMMAND_TOPIC_REPLICATION'])
+            self.check_single_translation(
+                c3_prop='confluent.metrics.topic.replication',
+                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC_REPLICATION'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.streams.num.stream.threads',
+                expected_val=self.test_env['CONTROL_CENTER_STREAMS_NUM_STREAM_THREADS'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.internal.topics.partitions',
+                expected_val=self.test_env['CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS'])
+            self.check_single_translation(
+                c3_prop='confluent.monitoring.interceptor.topic.partitions',
+                expected_val=self.test_env['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS'])
+            self.check_single_translation(
+                c3_prop='confluent.metrics.topic.max.message.bytes',
+                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC_MAX_MESSAGE_BYTES'])
+
+            # special props
+            self.check_single_translation(
+                c3_prop='confluent.license',
+                expected_val=self.test_env['CONTROL_CENTER_LICENSE'])
+            self.check_single_translation(
+                c3_prop='public.key.path',
+                expected_val=self.test_env['PUBLIC_KEY_PATH'])
+
+            # props with bad prefix
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.metric.topic',
+                expected_val=self.test_env['CONTROL_CENTER_METRIC_TOPIC'])
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.monitoring.topic',
+                expected_val=self.test_env['CONTROL_CENTER_MONITORING_TOPIC'])
+
+            # metrics topic precedence
+            self.check_single_translation(
+                c3_prop='confluent.metrics.topic.retention.ms',
+                expected_val=self.test_env['CONTROL_CENTER_METRICS_TOPIC_RETENTION_MS'])
+
+            # required props that weren't configured get empty string
+            self.check_single_translation(
+                c3_prop='confluent.controlcenter.data.dir',
+                expected_val="")
+            self.check_single_translation(
+                c3_prop='zookeeper.connect',
+                expected_val="")

--- a/control-center/test/test_control_center_props_validation.py
+++ b/control-center/test/test_control_center_props_validation.py
@@ -113,9 +113,10 @@ class PropsTranslationTest(unittest.TestCase):
         cls.filled_template = list(line.split("=") for line in actual)
 
     @classmethod
-    def configure_partially(cls, props, sample_size=1):
-        configured_props = random.sample(props.keys(), sample_size)
-        not_configured_props = list(set(props.keys()) - set(configured_props))
+    def configure_partially(cls, props):
+        # always randomly choose 1 prop from the list of props
+        configured_props = [random.choice(list(props.keys()))]
+        not_configured_props = props.keys() - configured_props
         return configured_props, not_configured_props
 
     @classmethod


### PR DESCRIPTION
Jira ticket: https://confluentinc.atlassian.net/browse/MMA-11806

Stop hardcoding the translations of `confluent.metrics.*` and `confluent.monitoring.interceptor.*` properties introduced in https://confluentinc.atlassian.net/browse/MMA-10870. This is because the hardcoded list might not be exhaustive, resulting in incorrect translation raised by MMA-11806.

Note: [control-center.properties.template](https://github.com/confluentinc/control-center-images/pull/52/files#diff-e85fff2a7ca9f755d48c8cc3f0ad6900f2dfabbc966ecc367f9b4d756f2c424c) has a few custom functions:
- SET_PROPERTIES (added due to some c3 properties have irregular translations)
- SET_PROPERTIES_WITH_ENV_TO_PROPS (standard way of translating properties)
- SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES (added due to the implementation limitation of [env_to_props](https://github.com/confluentinc/confluent-docker-utils/blob/5134c2d1fefb6b0380d5213b730e77fa9ec36eab/confluent/docker_utils/dub.py#L50))
- SET_PROPERTIES_WITH_SKIP_PROP_CHECK (added due to the implementation limitation of `env_to_props`)