### PR TITLE
RCCA-8895: Update control-center.properties.template file

### DIFF
--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -18,7 +18,7 @@
 {# ********************************************************************************************** #}
 {% set special_props = {
     'config.providers': ['CONFIG_PROVIDERS'],
-    'config.providers.securepass.class': ['CONFIG_PROVIDERS_SECUREPASS_CLASS']
+    'config.providers.securepass.class': ['CONFIG_PROVIDERS_SECUREPASS_CLASS'],
     'confluent.license': ['CONTROL_CENTER_LICENSE', 'CONTROL_CENTER_CONFLUENT_LICENSE'],
     'public.key.path': ['PUBLIC_KEY_PATH']
 } -%}

--- a/control-center/test/test_control_center_props_validation.py
+++ b/control-center/test/test_control_center_props_validation.py
@@ -473,7 +473,7 @@ class PropsTranslationTest(unittest.TestCase):
                 'CONTROL_CENTER_METRICS_TOPIC_MAX_MESSAGE_BYTES',
 
                 # special props
-                'CONFIG_PROVIDERS'
+                'CONFIG_PROVIDERS',
                 'CONFIG_PROVIDERS_SECUREPASS_CLASS',
                 'CONTROL_CENTER_LICENSE',
                 'CONTROL_CENTER_CONFLUENT_LICENSE',


### PR DESCRIPTION
This is a follow-up to #56. Template is missing "," in `control-center.properties.template`