### PR TITLE
[MMA-14178] Jenkins to Semaphore Migration - Sign Images

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -12,6 +12,7 @@ semaphore:
   maven_phase: 'package'
   maven_skip_deploy: true
   build_arm: true
+  sign_images: true
   os_types: ["ubi8"]
   nano_version: true
   use_packages: true


### PR DESCRIPTION
This PR is part of Jenkins to Semaphore Migration. In this PR we enable semaphore to sign images. This is required as per the comment mentioned at https://confluentinc.atlassian.net/browse/MMA-14178?focusedCommentId=2577551

More details on the work can be found at: [MMA-14178](https://confluentinc.atlassian.net/browse/MMA-14178?focusedCommentId=2539706)
Instructions used for migration: [Migration Guide](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3211693075/Jenkins+-+Semaphore+self+migration+guide#How-do-I-migrate-dockerfile%3F) & [More info on configs used](https://confluentinc.atlassian.net/browse/MMA-14178?focusedCommentId=2539706)

[MMA-14178]: https://confluentinc.atlassian.net/browse/MMA-14178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ