### PR TITLE
Revert the commit "Porting changes to 7.0.x"

### DIFF
--- a/control-center/pom.xml
+++ b/control-center/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.control-center-images</groupId>
         <artifactId>control-center-images-parent</artifactId>
-        <version>7.0.15-0</version>
+        <version>7.8.0-0</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.0.15-0, 7.0.16-0)</version>
+        <version>[7.8.0-0, 7.8.1-0)</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Control Center Docker Images</name>
     <description>Build files for Confluent's control center Docker images</description>
-    <version>7.0.15-0</version>
+    <version>7.8.0-0</version>
 
     <modules>
         <module>control-center</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>control-center</component.name>
-        <io.confluent.control-center-images.version>7.0.15-0</io.confluent.control-center-images.version>
+        <io.confluent.control-center-images.version>7.8.0-0</io.confluent.control-center-images.version>
     </properties>
 </project>


### PR DESCRIPTION
This PR reverts the commit https://github.com/confluentinc/control-center-images/commit/d8dacf1d9112e4f93e2a5c0bc66dae998b2109b5

Earlier as part of the PR https://github.com/confluentinc/control-center-images/pull/67 versions are updated. 
This PR is reverted at https://github.com/confluentinc/control-center-images/pull/75/files. However the above mentioned commit was not reverted as it was updated manually(not by semaphore bot) so reverting it manually.