### PR TITLE
Back-Porting Jenkins Semaphore migration changes

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -120,7 +120,7 @@ blocks:
   - name: Deploy AMD confluentinc/cp-enterprise-control-center
     dependencies: ["Build, Test, & Scan AMD"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       jobs:
         - name: Deploy AMD confluentinc/cp-enterprise-control-center ubi8
@@ -135,9 +135,12 @@ blocks:
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
             - docker push $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
             - docker push $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - sign-images $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - sign-images $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
             - export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$AMD_ARCH
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$PACKAGE_TAG
             - docker push $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - sign-images $PROD_IMAGE_NAME:$PACKAGE_TAG
   - name: Build & Test ARM
     dependencies: []
     run:
@@ -170,7 +173,7 @@ blocks:
   - name: Deploy ARM confluentinc/cp-enterprise-control-center
     dependencies: ["Build & Test ARM"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       agent:
         machine:
@@ -188,13 +191,16 @@ blocks:
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
             - docker push $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
             - docker push $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
+            - sign-images $PROD_IMAGE_NAME:$GIT_COMMIT_TAG
+            - sign-images $PROD_IMAGE_NAME:$BRANCH_BUILD_TAG
             - export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG$ARM_ARCH
             - docker tag $DEV_IMAGE_FULL $PROD_IMAGE_NAME:$PACKAGE_TAG
             - docker push $PROD_IMAGE_NAME:$PACKAGE_TAG
+            - sign-images $PROD_IMAGE_NAME:$PACKAGE_TAG
   - name: Create Manifest and Maven Deploy
     dependencies: ["Deploy AMD confluentinc/cp-enterprise-control-center", "Deploy ARM confluentinc/cp-enterprise-control-center"]
     run:
-      when: "branch = 'master' or branch =~ '[0-9]+\\.[0-9]+\\.[0-9]+'"
+      when: "branch = 'master' or branch =~ '^[0-9]+\\.[0-9]+\\.x$' or branch =~ '^[0-9]+\\.[0-9]+\\.[0-9]+(-cp[0-9]+)?-rc[0-9]+$'"
     task:
       jobs:
         - name: Create Manifest and Maven Deploy
@@ -211,9 +217,13 @@ blocks:
                 export GIT_TAG=$GIT_COMMIT$OS_TAG
                 docker manifest create $image:$GIT_TAG $image:$GIT_TAG$AMD_ARCH $image:$GIT_TAG$ARM_ARCH
                 docker manifest push $image:$GIT_TAG
+                docker pull $image:$GIT_TAG
+                sign-images $image:$GIT_TAG
                 export BRANCH_BUILD_TAG=$BRANCH_TAG-$BUILD_NUMBER$OS_TAG
                 docker manifest create $image:$BRANCH_BUILD_TAG $image:$BRANCH_BUILD_TAG$AMD_ARCH $image:$BRANCH_BUILD_TAG$ARM_ARCH
                 docker manifest push $image:$BRANCH_BUILD_TAG
+                docker pull $image:$BRANCH_BUILD_TAG
+                sign-images $image:$BRANCH_BUILD_TAG
                 export PACKAGE_TAG=$BRANCH_TAG-$PACKAGING_BUILD_NUMBER$OS_TAG
                 docker manifest create $image:$PACKAGE_TAG $image:$PACKAGE_TAG$AMD_ARCH $image:$PACKAGE_TAG$ARM_ARCH
                 docker manifest push $image:$PACKAGE_TAG

--- a/.semaphore/project.yml
+++ b/.semaphore/project.yml
@@ -14,7 +14,6 @@ spec:
     url: git@github.com:confluentinc/control-center-images.git
     run_on:
     - branches
-    - tags
     - pull_requests
     pipeline_file: .semaphore/semaphore.yml
     integration_type: github_app
@@ -26,7 +25,9 @@ spec:
       branches:
       - master
       - main
-      - /^v\d+\.\d+\.x$/
+      - /^\d+\.\d+\.x$/
+      - /^\d+\.\d+\.\d+-cp\d+-rc\d+$/
+      - /^\d+\.\d+\.\d+-rc\d+$/
       - /^gh-readonly-queue.*/
   custom_permissions: true
   debug_permissions:
@@ -42,3 +43,45 @@ spec:
   - pull_request
   - forked_pull_request
   - tag
+  tasks:
+  - name: cp-dockerfile-build
+    scheduled: False
+    branch: "master"
+    pipeline_file: .semaphore/cp_dockerfile_build.yml
+    parameters:
+    - name: CONFLUENT_VERSION
+      required: True
+    - name: PACKAGES_URL
+      required: True
+    - name: PACKAGES_MAVEN_URL
+      required: True
+    - name: PACKAGING_BUILD_NUMBER
+      required: True
+    - name: ALLOW_UNSIGNED
+      required: True
+      default_value: "False"
+      options:
+       - True
+       - False
+    - name: CONFLUENT_DEB_VERSION
+      required: True
+      default_value: "1"
+  - name: cp-dockerfile-promote
+    scheduled: False
+    branch: "master"
+    pipeline_file: .semaphore/cp_dockerfile_promote.yml
+    parameters:
+    - name: CONFLUENT_VERSION
+      required: True
+    - name: IMAGE_REVISION
+      required: True
+      default_value: "1"
+    - name: UPDATE_LATEST_TAG
+      required: True
+    - name: PACKAGING_BUILD_NUMBER
+      required: True
+    - name: PROMOTE_OS_TYPE
+      required: True
+      options:
+       - deb
+       - ubi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,8 +33,11 @@ global_job_config:
       # For PR Builds using Packaging
       - pip install confluent-release-tools
       - if [ $BRANCH_TAG == "master" ]; then export BUILD_KEY=$(pinto get-master-version); else export BUILD_KEY=$BRANCH_TAG; fi
-      - export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls s3://jenkins-confluent-packages/$BRANCH_TAG/ --no-paginate --recursive | grep "$BRANCH_TAG/[0-9]" | sort | tail -n 1 | awk '{print $4}' | awk -F
-        / '{print $2}')
+      - export PACKAGING_BUCKET="s3://jenkins-confluent-packages/$BRANCH_TAG/"
+      - export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls $PACKAGING_BUCKET --no-paginate | grep 'PRE' | awk '{print $NF}' | awk '{print substr($1, 1, length($1)-1)}' | sort -n | tail -n 1)
+      # Check if version is complete, otherwise use the previous version
+      - (aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/deb/ && aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/rpm/ && aws s3 ls $PACKAGING_BUCKET$LATEST_PACKAGING_BUILD_NUMBER/archive/)
+        || export LATEST_PACKAGING_BUILD_NUMBER=$(aws s3 ls $PACKAGING_BUCKET --no-paginate | grep 'PRE' | awk '{print $NF}' | awk '{print substr($1, 1, length($1)-1)}' | sort -n | tail -n 2 | head -n 1)
       - export CONFLUENT_VERSION=$(pinto get-version --build $BUILD_KEY --key confluent.version)
       - export DEFAULT_OS_TYPE="ubi"
       - export URL_CONFLUENT_VERSION=$(echo $CONFLUENT_VERSION | awk -F . '{print $1"."$2}')

--- a/control-center/pom.xml
+++ b/control-center/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.control-center-images</groupId>
         <artifactId>control-center-images-parent</artifactId>
-        <version>7.0.15-0</version>
+        <version>7.8.0-0</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.0.15-0, 7.0.16-0)</version>
+        <version>[7.8.0-0, 7.8.1-0)</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Control Center Docker Images</name>
     <description>Build files for Confluent's control center Docker images</description>
-    <version>7.0.15-0</version>
+    <version>7.8.0-0</version>
 
     <modules>
         <module>control-center</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>control-center</component.name>
-        <io.confluent.control-center-images.version>7.0.15-0</io.confluent.control-center-images.version>
+        <io.confluent.control-center-images.version>7.8.0-0</io.confluent.control-center-images.version>
     </properties>
 </project>


### PR DESCRIPTION
1. During Jenkins to Semaphore migration service-bot added some changes to an exiting PR confluentinc/control-center-images/pull/67. 
2. Earlier this PR was merged as is but we later realised all changes from this PR were not required so this PR is reverted at confluentinc/control-center-images/pull/75 & only required changes are cherry-picked in this PR.

Will make sure that the changes are reviewed by c3 & cp-build team.