### PR TITLE
Fix version bump in pom.xml for 7.7.x

### DIFF
--- a/control-center/pom.xml
+++ b/control-center/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.control-center-images</groupId>
         <artifactId>control-center-images-parent</artifactId>
-        <version>7.8.0-0</version>
+        <version>7.7.0-0</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-docker</artifactId>
-        <version>[7.8.0-0, 7.8.1-0)</version>
+        <version>[7.7.0-0, 7.7.1-0)</version>
     </parent>
 
     <groupId>io.confluent.control-center-images</groupId>
@@ -30,7 +30,7 @@
     <packaging>pom</packaging>
     <name>Control Center Docker Images</name>
     <description>Build files for Confluent's control center Docker images</description>
-    <version>7.8.0-0</version>
+    <version>7.7.0-0</version>
 
     <modules>
         <module>control-center</module>
@@ -38,6 +38,6 @@
 
     <properties>
         <component.name>control-center</component.name>
-        <io.confluent.control-center-images.version>7.8.0-0</io.confluent.control-center-images.version>
+        <io.confluent.control-center-images.version>7.7.0-0</io.confluent.control-center-images.version>
     </properties>
 </project>


### PR DESCRIPTION
**History**

1. During the early phase of jenkins to semaphore migration, there was a randomly dangling PR from Jenkins service bot confluentinc/control-center-images/pull/67 not sure on the origin of this but we suspect that some developer ran service bot and left changes/PR by service bot unmerged.
2. when service bot was run as part of Jenkins-Semaphore migration some of the commits were pushed to same PR.
3. This PR from service bot was raised to master branch.
4. Without realising that this PR contains old changes we megerd it(by changing the target branch to 7.0.x as Jenkins Semaphore migration changes should be back ported to all the branches) but later realised the issue and reverted it at confluentinc/control-center-images/pull/75
5. Since the base branch was changed to 7.0.x from master, versions were updated in all branches to 7.8. Ideally each branch should point it to its own version.

Goal of this PR is to fix this versioning issue.

**How to verify changes?**
Similar versions can be found in[ ksql-images/7.7.x/pom.xml ](https://github.com/confluentinc/ksql-images/blob/7.7.x/pom.xml)

**Next Steps**
1. Merge this PR 
2. pint merge with strategy our.
3. Do the same thing for rest of the branches.