### PR TITLE
[MMA-14178] MINOR: Push images to repository

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -17,6 +17,7 @@ semaphore:
   nano_version: true
   use_packages: true
   cp_images: true
+  push_latest: true
   tasks:
     - name: cp-dockerfile-build
       branch: master


### PR DESCRIPTION
Currently latest control-center-images image is not pushed to repository. Adding `push_latest: true` to enable this as per the request at https://confluent.slack.com/archives/C06N5PM0W0G/p1716356782234999