### PR TITLE
[MMA-14178] MINOR: Update python version

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: control-center-images
 lang: python
-lang_version: 2.7
+lang_version: 3.7
 git:
   enable: true
 codeowners:


### PR DESCRIPTION
Service Bot updates are failing due to python version related issue so updating python version to latest.

`CMD: sem-version python 2.7`
`[2024-05-22T07:42:25+00:00]: specified version of Python is end of life. Must be >= 3.7. If you think you received this message in error and you are a Confluent employee, see https://go/semaphore-support. Otherwise, contact the maintainer of the Semaphore project.`

Corresponding Build: https://semaphore.ci.confluent.io/jobs/3eb4ccc8-9cf2-4c22-b3d7-6bfddf87c3e8



