### PR TITLE
[MMA-115579] - reverting the control center template file to original state

### DIFF
--- a/control-center/include/etc/confluent/docker/control-center.properties.template
+++ b/control-center/include/etc/confluent/docker/control-center.properties.template
@@ -1,54 +1,134 @@
-
-{# required properties #}
-bootstrap.servers={{env['CONTROL_CENTER_BOOTSTRAP_SERVERS']}}
-zookeeper.connect={{env['CONTROL_CENTER_ZOOKEEPER_CONNECT']}}
-confluent.controlcenter.data.dir={{env['CONTROL_CENTER_DATA_DIR']}}
-confluent.monitoring.interceptor.topic.replication={{env.get('CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-confluent.controlcenter.internal.topics.replication={{env.get('CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-confluent.controlcenter.command.topic.replication={{env.get('CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-confluent.metrics.topic.replication={{env.get('CONTROL_CENTER_METRICS_TOPIC_REPLICATION', env['CONTROL_CENTER_REPLICATION_FACTOR'])}}
-
-{# optional properties #}
-{% set other_props = {
-    'CONTROL_CENTER_ID': 'confluent.controlcenter.id',
-    'CONTROL_CENTER_NAME': 'confluent.controlcenter.name',
-    'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC': 'confluent.monitoring.interceptor.topic',
-    'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_PARTITIONS': 'confluent.monitoring.interceptor.topic.partitions',
-    'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_RETENTION_MS': 'confluent.monitoring.interceptor.topic.retention.ms',
-    'CONTROL_CENTER_INTERNAL_TOPICS_PARTITIONS': 'confluent.controlcenter.internal.topics.partitions',
-    'CONTROL_CENTER_INTERNAL_TOPICS_RETENTION_MS': 'confluent.controlcenter.internal.topics.retention.ms',
-    'CONTROL_CENTER_INTERNAL_TOPICS_CHANGELOG_SEGEMENT_BYTES': 'confluent.controlcenter.internal.topics.changelog.segment.bytes',
-    'CONTROL_CENTER_LICENSE': 'confluent.license',
-    'CONTROL_CENTER_CONFLUENT_LICENSE': 'confluent.license',
-    'CONFLUENT_METRICS_TOPIC_PARTITION': 'confluent.metrics.topic.partitions',
-    'CONFLUENT_METRICS_TOPIC_REPLICATION': 'confluent.metrics.topic.replication',
-    'CONFLUENT_SUPPORT_METRICS_ENABLE': 'confluent.support.metrics.enable',
-    'CONFLUENT_METADATA_BOOTSTRAP_SERVER_URLS': 'confluent.metadata.bootstrap.server.urls',
-    'CONFLUENT_METADATA_BASIC_AUTH_USER_INFO':'confluent.metadata.basic.auth.user.info',
-    'PUBLIC_KEY_PATH': 'public.key.path',
-    'CONTROL_CENTER_CPREST_URL': 'cprest.url',
-    'CONFIG_PROVIDERS': 'config.providers',
-    'CONFIG_PROVIDERS_SECUREPASS_CLASS': 'config.providers.securepass.class',
+{# ********************************************************************************************** #}
+{# IMPORTANT TO NOTE: These properties are required properties, and they not only have special #}
+{# translations but also have a list of valid translations. #}
+{# ********************************************************************************************** #}
+{% set required_props = {
+  'bootstrap.servers': ['CONTROL_CENTER_BOOTSTRAP_SERVERS'],
+  'zookeeper.connect': ['CONTROL_CENTER_ZOOKEEPER_CONNECT'],
+  'confluent.controlcenter.data.dir': ['CONTROL_CENTER_DATA_DIR'],
+  'confluent.monitoring.interceptor.topic.replication': ['CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', 'CONTROL_CENTER_REPLICATION_FACTOR'],
+  'confluent.controlcenter.internal.topics.replication': ['CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', 'CONTROL_CENTER_REPLICATION_FACTOR'],
+  'confluent.controlcenter.command.topic.replication': ['CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', 'CONTROL_CENTER_REPLICATION_FACTOR'],
+  'confluent.metrics.topic.replication': ['CONTROL_CENTER_METRICS_TOPIC_REPLICATION', 'CONFLUENT_METRICS_TOPIC_REPLICATION', 'CONTROL_CENTER_REPLICATION_FACTOR']
 } -%}
 
-{% set excludes = [] -%}
+{# ********************************************************************************************** #}
+{# IMPORTANT TO NOTE: These properties have uncommon prefixes. Though ideally C3 properties should #}
+{# have the common prefix `confluent.controlcenter.`, which translates to `CONTROL_CENTER_`. #}
+{# ********************************************************************************************** #}
+{% set special_props = {
+    'config.providers': ['CONFIG_PROVIDERS'],
+    'config.providers.securepass.class': ['CONFIG_PROVIDERS_SECUREPASS_CLASS'],
+    'confluent.license': ['CONTROL_CENTER_LICENSE', 'CONTROL_CENTER_CONFLUENT_LICENSE'],
+    'public.key.path': ['PUBLIC_KEY_PATH']
+} -%}
 
-{% for k, property in other_props.items() -%}
-{{ excludes.append(k) }}
-{% if env.get(k) != None -%}
-{{property}}={{env[k]}}
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES should be used for properties that have special translation, and have a list of #}
+{# valid translations that could be used. For example, confluent.metrics.topic has two valid #}
+{# possible translations: [CONTROL_CENTER_METRICS_TOPIC_REPLICATION, CONFLUENT_METRICS_TOPIC_REPLICATION]. #}
+{# SET_PROPERTIES will try all the possible translations. If a property is required and none of the possible #}
+{# translation was configured in the env variables, then the property is set to an empty string. #}
+{# If a property is not required and none of the possible translation was configured in the env #}
+{# variables, nothing will be set. Each translated property is appended to excludes as well. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES(properties, required, excludes=[]) -%}
+{% for property, ks in properties.items() -%}
+{# ENCAPSULATE THE VALUE AS RESULT #}
+{% set ns = namespace(result=None) -%}
+{# FIND THE FIRST NOT NONE VALUE AND SET IT #}
+{% for k in ks -%}
+  {% set _ = excludes.append(k) -%}
+  {% if ns.result == None and env.get(k) != None -%}
+    {% set ns.result = env.get(k) -%}
+  {% endif -%}
+{% endfor -%}
+{# FILL THE TEMPLATE. IF THE PROPERTY IS REQUIRED, SET TO ITS VALUE, OR EMPTY STRING IF NONE. #}
+{# IF THE PROPERTY IS NOT REQUIRED, SET THE VALUE ONLY IF NOT NONE. #}
+{% if required and ns.result != None -%}
+  {{property}}={{ns.result}}
+{% elif required and ns.result == None -%}
+  {{property}}=
+{% elif not required and ns.result != None -%}
+  {{property}}={{ns.result}}
 {% endif -%}
 {% endfor -%}
+{% endmacro -%}
 
-{% set excludes = excludes + ['CONTROL_CENTER_BOOTSTRAP_SERVERS', 'CONTROL_CENTER_ZOOKEEPER_CONNECT', 'CONTROL_CENTER_DATA_DIR', 'CONTROL_CENTER_MONITORING_INTERCEPTOR_TOPIC_REPLICATION', 'CONTROL_CENTER_INTERNAL_TOPICS_REPLICATION', 'CONTROL_CENTER_COMMAND_TOPIC_REPLICATION', 'CONTROL_CENTER_METRICS_TOPIC_REPLICATION'] -%}
-
-{% set command_props = env_to_props('CONTROL_CENTER_', 'confluent.controlcenter.', exclude=excludes) -%}
-{% for name, value in command_props.items() -%}
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_ENV_TO_PROPS should be used for properties that have a fixed translation #}
+{# to the env variable. For example, everything starts with CONTROL_METADATA_ deterministically #}
+{# always translates to confluent.metadata. Each translated property is NOT appended to excludes
+{# (because of the way env_to_props was implemented). #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_ENV_TO_PROPS(env_prefix, prop_prefix, excludes=[]) -%}
+{% set props = env_to_props(env_prefix, prop_prefix, exclude=excludes) -%}
+{% for name, value in props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
+{% endmacro -%}
 
-{# NOTE: the env var prefix is CONTROL_CENTER_METRICS_ but the property prefix is confluent.metrics. #}
-{% set metrics_props = env_to_props('CONTROL_CENTER_METRICS_', 'confluent.metrics.', exclude=excludes) -%}
-{% for name, value in metrics_props.items() -%}
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES should be used for properties that have two #}
+{# fixed translations to the env variables. For example, for metrics properties, both #}
+{# CONTROL_CENTER_METRICS_ and CONFLUENT_METRICS_ deterministically always translate to #}
+{# confluent.metrics. However, the first env prefix takes precedence. Therefore, this function #}
+{# only sets a property that starts with the secondary env prefix if the property hasn't been set #}
+{# with the primary env prefix. We shouldn't find two copies of the same property being translated #}
+{# by both the primary and the secondary env prefix. Each translated property is NOT appended to #}
+{# excludes. #}
+{# Note this func could be deleted if env_to_props appends each translated property to excludes. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES(primary_env_prefix, secondary_env_prefix, prop_prefix, excludes=[]) -%}
+{% set primary_props = env_to_props(primary_env_prefix, prop_prefix, exclude=excludes) -%}
+{% set secondary_props = env_to_props(secondary_env_prefix, prop_prefix, exclude=excludes) -%}
+{# SET PROPERTIES PREFIXED WITH primary_env_prefix BECAUSE THEY ALWAYS TAKE PRECEDENCE #}
+{% for name, value in primary_props.items() -%}
 {{name}}={{value}}
 {% endfor -%}
+{# SET PROPERTIES PREFIXED WITH secondary_env_prefix ONLY IF THE PROP HASN'T BEEN SET YET #}
+{% for name, value in secondary_props.items() -%}
+{% if name not in primary_props.keys() -%}
+{{name}}={{value}}
+{% endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+{# ********************************************************************************************** #}
+{# SET_PROPERTIES_WITH_SKIP_PROP_CHECK should be used for properties that in general have a fixed #}
+{# translation, but have a few props prefixes that should be skipped. For example, properties #}
+{# that start with CONTROL_CENTER_ in general translates to confluent.controlcenter. However, #}
+{# CONTROL_CENTER_METRICS_* and CONTROL_CENTER_MONITORING_INTERCEPTOR_* also start with #}
+{# CONTROL_CENTER_ but they are special and should be skipped. Each translated property is NOT
+{# appended to excludes. #}
+{# Note this func could be deleted if env_to_props appends each translated property to excludes. #}
+{# ********************************************************************************************** #}
+{% macro SET_PROPERTIES_WITH_SKIP_PROP_CHECK(env_prefix, prop_prefix, excludes=[], skip_prop_prefix=[], skip_props=[]) -%}
+{% set props = env_to_props(env_prefix, prop_prefix, exclude=excludes) -%}
+{# CHECK IF NAME STARTS WITH A PROPERTY PREFIX THAT SHOULD BE SKIPPED #}
+{% for name, value in props.items() -%}
+{% for w in skip_prop_prefix -%}
+{% if name.startswith(w) %}
+{% set _ = skip_props.append(name) -%}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+{# SET IN TEMPLATE FILE ONLY IF NAME SHOULDN'T BE SKIPPED #}
+{% for name, value in props.items() -%}
+{% if not name in skip_props -%}
+{{name}}={{value}}
+{% endif -%}
+{% endfor -%}
+{% endmacro -%}
+
+{% set excludes = [] -%}
+{{ SET_PROPERTIES(required_props, true, excludes) }}
+{{ SET_PROPERTIES(special_props, false, excludes) }}
+
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONTROL_CENTER_MONITORING_INTERCEPTOR_', 'confluent.monitoring.interceptor.', excludes) }}
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_METADATA_', 'confluent.metadata.', excludes) }}
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS('CONFLUENT_SUPPORT_', 'confluent.support.', excludes) }}
+
+{{ SET_PROPERTIES_WITH_ENV_TO_PROPS_WITH_TWO_PREFIXES('CONTROL_CENTER_METRICS_', 'CONFLUENT_METRICS_', 'confluent.metrics.', excludes) }}
+
+{{ SET_PROPERTIES_WITH_SKIP_PROP_CHECK('CONTROL_CENTER_', 'confluent.controlcenter.', excludes, ['confluent.controlcenter.metrics.', 'confluent.controlcenter.monitoring.interceptor.']) }}


### PR DESCRIPTION
this file was update unintentionally in one of service bot PR  https://github.com/confluentinc/control-center-images/pull/75

https://confluent.slack.com/archives/C01T51MQKEF/p1717580350066479

Some PR checks are failing, these checks are running on jenkins and some paths are not updated. Ignoring these checks. The main PR job is moved to semaphore which is passing.

] ===> Installing control-center...
11:11:34  [INFO] curl: (22) The requested URL returned error: 404 Not Found
11:11:34  [INFO] 
11:11:34  [INFO] error: https://s3-us-west-2.amazonaws.com/dev-confluent-packages-654654529379-us-west-2/7.0.x/null/rpm/7.0/archive.key: import read failed(2).