### PR TITLE
Fix forbidden issue in deploy step in CI

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -63,3 +63,4 @@ code_artifact:
   package_paths:
     - maven-snapshots/maven/io.confluent/control-center-images
     - maven-snapshots/maven/io.confluent/control-center-images-parent
+    - maven-snapshots/maven/io.confluent.control-center-images/control-center-images-parent


### PR DESCRIPTION
Deploy step is failing in CI with the error
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project control-center-images-parent: Failed to deploy artifacts: Could not transfer artifact io.confluent.control-center-images:control-center-images-parent:pom:7.2.12-7 from/to confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/): status code: 403, reason phrase: Forbidden (403) -> [Help 1]00:34`

As per the suggestion from devprod team [here](https://confluent.slack.com/archives/C01RVE8R162/p1723532973293369?thread_ts=1721020933.826369&cid=C01RVE8R162) making the changes

Previous build failure: https://semaphore.ci.confluent.io/jobs/b5eec7b7-e1d8-4235-8af7-fdbcf1210938