### PR TITLE
Fix forbidden issue in deploy step in CI for enterprise 

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -64,3 +64,4 @@ code_artifact:
     - maven-snapshots/maven/io.confluent/control-center-images
     - maven-snapshots/maven/io.confluent/control-center-images-parent
     - maven-snapshots/maven/io.confluent.control-center-images/control-center-images-parent
+    - maven-snapshots/maven/io.confluent.control-center-images/cp-enterprise-control-center


### PR DESCRIPTION
Deploy step is failing in CI with the error
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project control-center-images-parent: Failed to deploy artifacts: Could not transfer artifact io.confluent.control-center-images:control-center-images-parent:pom:7.1.14-12 from/to confluent-codeartifact-internal (https://confluent-519856050701.d.codeartifact.us-west-2.amazonaws.com/maven/maven-snapshots/): status code: 403, reason phrase: Forbidden (403) -> [Help 1]`

As per the suggestion from devprod & build team [here](https://confluent.slack.com/archives/C01RVE8R162/p1723544491939869?thread_ts=1721020933.826369&cid=C01RVE8R162) making the changes

Previous build failure: https://semaphore.ci.confluent.io/jobs/1c989b0b-5de3-45fc-883a-9b8e4db4bc25