### PR TITLE
Increase docker build time limit RC branch

### DIFF
--- a/.semaphore/cp_dockerfile_build.yml
+++ b/.semaphore/cp_dockerfile_build.yml
@@ -14,7 +14,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 1
+  hours: 2
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.[0-9]+'"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -14,7 +14,7 @@ fail_fast:
     when: "true"
 
 execution_time_limit:
-  hours: 1
+  hours: 2
 
 queue:
   - when: "branch != 'master' and branch !~ '[0-9]+\\.[0-9]+\\.[0-9]+'"


### PR DESCRIPTION
The docker build is timing out for May release of FedRAMP due to 1 hr execution limit.
https://semaphore.ci.confluent.io/jobs/e8f48e86-d9a6-4ffd-a8fa-5e3bc1a59287