### PR TITLE
DP-18712: fetch a repo-scoped DockerHub token in the promote prologue

### DIFF
--- a/.semaphore/cp_dockerfile_promote.yml
+++ b/.semaphore/cp_dockerfile_promote.yml
@@ -44,8 +44,8 @@ global_job_config:
       - export BRANCH_TAG=$(echo $SEMAPHORE_GIT_BRANCH | tr / -)
       - export DOCKER_PROD_REGISTRY="519856050701.dkr.ecr.us-west-2.amazonaws.com/docker/prod/"
       - export PROMOTED_TAG_PREFIX="$CONFLUENT_VERSION-$IMAGE_REVISION"
-      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
-      - docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+      - if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+      - . get-auth-token dockerhub
       - export AMD_ARCH=.amd64
       - export ARM_ARCH=.arm64
       - export COMMUNITY_DOCKER_REPOS=""


### PR DESCRIPTION
## What

Replaces the org-wide static DockerHub login in the cp-dockerfile **promote** prologue with a per-project, repo-scoped credential fetch, and fixes a latent bug in the `PACKAGING_BUILD_NUMBER` default.

```diff
- if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export $PACKAGING_BUILD_NUMBER="latest"; fi
- docker login --username $DOCKERHUB_USER --password $DOCKERHUB_APIKEY
+ if [[ ! "$PACKAGING_BUILD_NUMBER" ]]; then export PACKAGING_BUILD_NUMBER="latest"; fi
+ . get-auth-token dockerhub
```

## Why these changes are correct and safe

**`. get-auth-token dockerhub`** — INC-9669 corrective action (DP-18712/DP-18713): instead of exporting one org-wide DockerHub token into every CI job, publishing jobs fetch a repo-scoped Organization Access Token from SSM on demand. `get-auth-token` is already on the CI agent image (ci-build-agent-infra#2626, merged); **sourced** (`.`) it reads `/dockerhub/write/confluentinc/control-center-images` from SSM and performs the `docker login` in the current shell, so every later `docker push` keeps working with no other edits. Sourcing (not executing) is required for the login to persist into the same shell; this is the exact form validated in schema-registry-images and generated by the cc-service-bot template (#2112).

**`PACKAGING_BUILD_NUMBER` fix** — the old line expanded `$PACKAGING_BUILD_NUMBER` before `export`, so an empty value ran `export ="latest"` (never set the default). Dropping the `$` makes the fallback assign correctly. When the var is already set the `if` guard skips the line, so the normal path is unchanged.

**Safety / blast radius:** promote-only file; only the login step + an empty-value fallback change. Pre-PR review over the diff found no issues (YAML valid, all later `docker push` calls covered by the sourced login, correct shell).

## Rollout

Base of the forward-merge rollout: **7.5.x** (oldest supported branch). After merge, `apply-pint-merge` (`FROM_BRANCH=7.5.x`) propagates it forward through the newer supported branches to master. Validated locally: promote file present on all supported branches, edited region byte-identical, and the pint tree is clean (0 unmerged commits) at every boundary, so the forward-merge is conflict-free.